### PR TITLE
Fix versioning configuration so request.version contains the API version

### DIFF
--- a/api_server/api/urls.py
+++ b/api_server/api/urls.py
@@ -28,5 +28,5 @@ v1 = [
 ]
 
 urlpatterns = [
-    path("v1/", include(v1)),
+    path("v1/", include((v1, 'api'), namespace='v1')),
 ]

--- a/api_server/task_manager/settings.py
+++ b/api_server/task_manager/settings.py
@@ -132,7 +132,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
-    ]
+    ],
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
 }
 
 AUTH_USER_MODEL="api.CustomUser"


### PR DESCRIPTION
# What are you trying to achieve?

This PR fixes the versioning configuration to ensure the api version information is rightly populated in the request, allowing the developers to choose the right serializer to use according to the API version used to make the request.

# Context about the changes

Since API versioning was one of the things I had to deal with in my previous team, I got really curious to understand how DRF solves the problem and I was quite impressed by how simple it is to version APIs using it.

Then I noticed the version was not being passed properly in the requests because it was missing the `namespace` in the urls definition, but also, the `DEFAULT_VERSIONING_CLASS` setting in `settings.py`.

# Before

<img width="1189" alt="Screenshot 2023-06-08 at 3 57 02 PM" src="https://github.com/newswangerd/modern-web-app-demo/assets/411301/42caf13c-21c8-4e64-a375-96bdd29e5346">

# After

<img width="1205" alt="Screenshot 2023-06-08 at 3 58 36 PM" src="https://github.com/newswangerd/modern-web-app-demo/assets/411301/689248ab-e86b-41ce-a6b3-9dd0aa21999a">

# Is it safe to rollback this PR?

Yup and very straightforward.