### PR TITLE
Add pytest setup and initial tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Test API Server
+on:
+  push:
+    paths-ignore:
+      - 'web_client/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -U pytest pytest-django
+      - name: Run tests using pytest
+        working-directory: api_server
+        run: pytest .

--- a/api_server/api/tests.py
+++ b/api_server/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/api_server/api/tests/test_models.py
+++ b/api_server/api/tests/test_models.py
@@ -1,0 +1,44 @@
+from django.db.utils import IntegrityError
+
+from ..models import CustomUser, TaskList, Task
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_custom_user_creation():
+    user = CustomUser.objects.create_user(username='test', password='test', email='test@test.com')
+    assert 'test', user.username
+    assert 'test@test.com', user.email
+
+
+@pytest.mark.django_db
+def test_custom_user_email_is_unique():
+    CustomUser.objects.create_user(username='test', password='test', email='test@test.com')
+
+    with pytest.raises(IntegrityError):
+        CustomUser.objects.create_user(username='test2', password='test2', email='test@test.com')
+
+
+@pytest.mark.django_db
+def test_task_list_creation():
+    user = CustomUser.objects.create_user(username='test', password='test', email='test@test.com')
+    task_list = TaskList.objects.create(
+        name='Groceries',
+        description='We\'re starving, time to go to the supermarket',
+        user=user,
+    )
+
+    task = Task.objects.create(
+        name='tomatoes',
+        description='Get italian tomatoes, not the cherry ones.',
+        is_complete=False,
+        list=task_list,
+    )
+
+    assert 'Groceries', task_list.name
+    assert 'We\'re starving, time to go to the supermarket', task_list.description
+    assert user, task_list.user
+
+    assert 'tomatoes', task.name
+    assert 'Get Italian tomatoes, not the cherry ones.', task.description

--- a/api_server/api/tests/test_views.py
+++ b/api_server/api/tests/test_views.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api.models import CustomUser
+
+
+class TaskTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user = CustomUser.objects.create_user(username='apitest')
+        user.set_password("apitest")
+        user.save()
+
+    def test_list_tasks_forbidden(self):
+        """
+        Ensure tasks cannot be listed without authentication.
+        """
+        url = reverse('tasks-list')
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_tasks_allowed(self):
+        """
+        Ensure tasks can be listed when authenticated.
+        """
+        url = reverse('tasks-list')
+        client = self.client
+        client.login(username='apitest', password='apitest')
+
+        response = client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api_server/pytest.ini
+++ b/api_server/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = task_manager.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
# What are you trying to achieve?

Add support to test the application using `pytest` but also, adding some initial tests for Models and for the API.

# Context about the changes

The idea behind this PR is to get the testing infrastructure up, with some tests, so new developers can follow the patterns there and keep adding tests as the project grows.

Good test coverage will also allow us to rely on some tooling like Dependabot to update dependencies and solve security incidents faster.

Finally, I decided to setup up Github Actions to shorten the feedback look to developers and let them know right away if their changes break the codebase tests.

# How it looks like?

<img width="914" alt="Screenshot 2023-06-08 at 5 10 46 PM" src="https://github.com/newswangerd/modern-web-app-demo/assets/411301/2d68aac6-a029-491f-9b34-19d1f1ef52e8">

# What about the missing tests?

I'll add them in other PR so we can get the testing infrastructure up and running faster.

# Is it safe to rollback this PR?

Yup and very straightforward.